### PR TITLE
feat(spatial): add geometry

### DIFF
--- a/types/SpatialResourceType.json
+++ b/types/SpatialResourceType.json
@@ -14,6 +14,10 @@
         "totalLength": {
           "$ref": "../types/LengthMeasureType.json",
           "description": "If the feature is linear, the total length. If a polygon, the perimeter (default is in metres - MTR)"
+        },
+        "geometry": {
+          "$ref": "https://raw.githubusercontent.com/daniel-buchanan/rfc7946-schema/main/schema/geometry.json",
+          "description": "The geometry for the spatial feature"
         }
       }
     }


### PR DESCRIPTION
Add geometry to the spatial feature.

@cookeac I'm not sure why this isn't in the source Datalinker repository - is there a reason that the geometry has been left out?

If it shouldn't be here, happy to shift it back into the Pure Farming schema.