### PR TITLE
fix: specify full url of the operation type

### DIFF
--- a/resources/OperationRecordResource.json
+++ b/resources/OperationRecordResource.json
@@ -12,7 +12,7 @@
     "properties": {
         "operation": {
             "type": "string",
-            "description": "Encoding of the field operation. See well-known/operations-and-methods.md"
+            "description": "Encoding of the field operation. See https://raw.githubusercontent.com/Datalinker-Org/Geospatial/master/well-known/operations-and-methods.md"
         },
         "operationName": {
             "type": "string",


### PR DESCRIPTION
This improves the current documentation experience - at the moment you can't figure out where on the PF developer hub these operation types are!

Currently:
![image](https://github.com/Pure-Farming/DataLinker-Geospatial/assets/3358790/0cc4c386-3e77-4f05-9bb4-a52e72d88f9a)
